### PR TITLE
List priority bugfix

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 		<meta charset="utf-8" />
 		<meta name="author" content="Alex Lindeman" />
 		<meta name="created" content="2015-11-02" />
-		<meta name="version" content="1.1.0" />
+		<meta name="version" content="1.1.1" />
 		<meta name="description" content="The configuration page for WMATA With You, a Pebble smartwatch app for public transport in and around Washington, D.C., available at https://apps.getpebble.com/applications/5404f8e0ec33d19e2200008b" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.3/normalize.min.css" />

--- a/scripts.js
+++ b/scripts.js
@@ -391,8 +391,8 @@ function get_query_param(variable, default_value) {
 // gathers configuration from the page
 function get_config_data() {
 	var options = {
-		'buses-first': buses_first_field.val(),
-		'closest-things': closest_things_field.val(),
+		'buses-first': parseInt(buses_first_field.val()),
+		'closest-things': parseInt(closest_things_field.val()),
 		'safetrack-warning': safetrack_warning_field.val(),
 		'selection-color': selection_color_field.val(),
 		'saved-bus': JSON.stringify(saved_bus),


### PR DESCRIPTION
"Show buses/trains first" setting may not be working because strings always evaluate to `true`. This forces them into integers before sending the config data back to the Pebble, which should respect the setting properly.
